### PR TITLE
Add virtual environment folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ pyhiveapi.egg-info
 .tox
 .cache
 test*
+
+# virtual environment folder
+.venv/


### PR DESCRIPTION
Add virtual environment sub-folder to `.gitignore` file. I've used the common `.venv` name for the folder. I'm using this for development and testing.