### PR TITLE
[WIP] 19 - Add schedule support for single zone heating in Hive boiler module

### DIFF
--- a/pyhiveapi/apyhiveapi/api/hive_api.py
+++ b/pyhiveapi/apyhiveapi/api/hive_api.py
@@ -208,18 +208,12 @@ class HiveApi:
 
     def setState(self, n_type, n_id, **kwargs):
         """Set the state of a Device."""
-        jsc = (
-            "{"
-            + ",".join(
-                ('"' + str(i) + '": ' '"' + str(t) + '" ' for i, t in kwargs.items())
-            )
-            + "}"
-        )
+        json_string = json.dumps(kwargs)
 
         url = self.urls["base"] + self.urls["nodes"].format(n_type, n_id)
 
         try:
-            response = self.request("POST", url, jsc)
+            response = self.request("POST", url, json_string)
             self.json_return.update({"original": response.status_code})
             self.json_return.update({"parsed": response.json()})
         except (OSError, RuntimeError, ZeroDivisionError, ConnectionError):

--- a/pyhiveapi/apyhiveapi/api/hive_async_api.py
+++ b/pyhiveapi/apyhiveapi/api/hive_async_api.py
@@ -213,18 +213,11 @@ class HiveApiAsync:
 
     async def setState(self, n_type, n_id, **kwargs):
         """Set the state of a Device."""
-        jsc = (
-            "{"
-            + ",".join(
-                ('"' + str(i) + '": ' '"' + str(t) + '" ' for i, t in kwargs.items())
-            )
-            + "}"
-        )
-
+        json_string = json.dumps(kwargs)
         url = self.urls["nodes"].format(n_type, n_id)
         try:
             await self.isFileBeingUsed()
-            await self.request("post", url, data=jsc)
+            await self.request("post", url, data=json_string)
         except (FileInUse, OSError, RuntimeError, ConnectionError) as e:
             if e.__class__.__name__ == "FileInUse":
                 return {"original": "file"}


### PR DESCRIPTION
## Description
Adds support for getting and setting the weekly schedule for **heating only** for a central Hive heating boiler module with a **single heating zone**.

## Implementation
- [x] Augment sync `api.setState()` function to handle dictionary states
- [x] Augment async `api.setState()` function to handle dictionary states
- [ ] Add `heating.getSchedule()` function
- [ ] Add `heating.setSchedule()` function

## Tests

## Scope
Partially addresses #19

Includes:
- Schedule support for single heating zone for single central boiler module.

Excludes:
- Schedule support for hot water
- Schedule support for multiple heating zones
- Schedule support for individual radiator TRVs