### PR TITLE
fix data type for refresh token

### DIFF
--- a/pyhiveapi/apyhiveapi/api/hive_auth_async.py
+++ b/pyhiveapi/apyhiveapi/api/hive_auth_async.py
@@ -537,7 +537,7 @@ class HiveAuthAsync:
         if self.client is None:
             await self.async_init()
         result = None
-        auth_params = ({"REFRESH_TOKEN": token},)
+        auth_params = {"REFRESH_TOKEN": token}
         if self.device_key is not None:
             auth_params = {
                 "REFRESH_TOKEN": token,


### PR DESCRIPTION
Hitting this issue when trying to auth in Home Assistant


```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 387, in async_setup
    result = await component.async_setup_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/hive/__init__.py", line 89, in async_setup_entry
    devices = await hive.session.startSession(hive_config)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/apyhiveapi/session.py", line 503, in startSession
    await self.getDevices("No_ID")
  File "/usr/local/lib/python3.11/site-packages/apyhiveapi/session.py", line 426, in getDevices
    await self.hiveRefreshTokens()
  File "/usr/local/lib/python3.11/site-packages/apyhiveapi/session.py", line 304, in hiveRefreshTokens
    result = await self.auth.refresh_token(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/apyhiveapi/api/hive_auth_async.py", line 548, in refresh_token
    result = await self.loop.run_in_executor(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/botocore/client.py", line 391, in _api_call
    return self._make_api_call(operation_name, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/botocore/client.py", line 691, in _make_api_call
    request_dict = self._convert_to_request_dict(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/botocore/client.py", line 739, in _convert_to_request_dict
    request_dict = self._serializer.serialize_to_request(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/botocore/validate.py", line 360, in serialize_to_request
    raise ParamValidationError(report=report.generate_report())
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter AuthParameters, value: ({'REFRESH_TOKEN': '<redacted>'},), type: <class 'tuple'>, valid types: <class 'dict'>
```

Similar to issue reported in https://github.com/home-assistant/core/issues/88981