### PR TITLE
Fix TypeError

### DIFF
--- a/pyhiveapi/apyhiveapi/session.py
+++ b/pyhiveapi/apyhiveapi/session.py
@@ -371,11 +371,8 @@ class HiveSession:
             cameraRecording = self.openFile("camera.json")
         elif self.tokens is not None:
             cameraImage = await self.api.getCameraImage(device)
-            hasCameraRecording = bool(["parsed"]["events"][0]["hasRecording"])
-            if (
-                cameraImage["parsed"]["events"][0]["hasRecording"] is True
-                and hasCameraRecording
-            ):
+            hasCameraRecording = bool(cameraImage["parsed"]["events"][0]["hasRecording"])
+            if hasCameraRecording:
                 cameraRecording = await self.api.getCameraRecording(
                     device, cameraImage["parsed"]["events"][0]["eventId"]
                 )


### PR DESCRIPTION
```py
>>> bool(["parsed"]["events"][0]["hasRecording"])
<stdin>:1: SyntaxWarning: list indices must be integers or slices, not str; perhaps you missed a comma?
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: list indices must be integers or slices, not str
```