### PR TITLE
Support heating groups

### DIFF
--- a/pyhiveapi/apyhiveapi/session.py
+++ b/pyhiveapi/apyhiveapi/session.py
@@ -528,7 +528,11 @@ class HiveSession:
             p = self.data.products[aProduct]
             if "error" in p:
                 continue
-            if p.get("isGroup", False):
+            # Only consider single items or heating groups
+            if (
+                p.get("isGroup", False)
+                and self.data.products[aProduct]["type"] not in HIVE_TYPES["Heating"]
+            ):
                 continue
             product_list = PRODUCTS.get(self.data.products[aProduct]["type"], [])
             for code in product_list:


### PR DESCRIPTION
Split Heating from the other products to allow the grouped heating controls to be exposed to Home Assistant. This will expose the first TRV in the group. as the control. Hive appears to change all trv's in the group when one of them change.

* Move the product_list check into the if statement to avoid processing the non-heating products.