### PR TITLE
Expose motion sensor temperature

### DIFF
--- a/pyhiveapi/apyhiveapi/helper/const.py
+++ b/pyhiveapi/apyhiveapi/helper/const.py
@@ -60,6 +60,7 @@ sensor_commands = {
     "DOG_BARK": "self.session.hub.getDogBarkStatus(device)",
     "GLASS_BREAK": "self.session.hub.getGlassBreakStatus(device)",
     "Camera_Temp": "self.session.camera.getCameraTemperature(device)",
+    "Current_Temperature": "self.session.heating.getCurrentTemperature(device)",
     "Heating_Current_Temperature": "self.session.heating.getCurrentTemperature(device)",
     "Heating_Target_Temperature": "self.session.heating.getTargetTemperature(device)",
     "Heating_State": "self.session.heating.getState(device)",
@@ -133,6 +134,7 @@ PRODUCTS = {
     #    ],
     "motionsensor": [
         'addList("binary_sensor", p)',
+        'addList("sensor", p, haName=" Current Temperature", hiveType="Current_Temperature", category="diagnostic")',
     ],
     "contactsensor": ['addList("binary_sensor", p)'],
 }


### PR DESCRIPTION
Add temp sensor for the motion sensor. This can re-use the heating API to query the device state, but has a different name to avoid creating an extra entity on the heating devices.

This can be used in HomeAssistant by adding a new sensor type to homeassistant/components/hive/sensor.py

     SensorEntityDescription(
        key="Current_Temperature",
        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
        state_class=SensorStateClass.MEASUREMENT,
        device_class=SensorDeviceClass.TEMPERATURE,
        entity_category=EntityCategory.DIAGNOSTIC,
    ),