### PR TITLE
Add unasync rule to convert 'asycio.Lock' to 'threading.Lock' in session.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,16 @@ setup(
                     "/pyhiveapi/",
                     additional_replacements={
                         "apyhiveapi": "pyhiveapi",
+                        "asyncio": "threading",
                     },
-                )
+                ),
+                unasync.Rule(
+                    "/apyhiveapi/api/",
+                    "/pyhiveapi/api/",
+                    additional_replacements={
+                        "apyhiveapi": "pyhiveapi",
+                    },
+                ),
             ]
         )
     },


### PR DESCRIPTION
This patch addresses the issue described in #74. When `pyhiveapi` is [packaged via `unasync`](https://github.com/Pyhass/Pyhiveapi/blob/05d5ae8a664160e2056906b24bba44e80729b52a/setup.py#L23-L33), it removes the `await` from [this `asyncio.Lock` acquisition in `HiveSession.updateData`](https://github.com/Pyhass/Pyhiveapi/blob/05d5ae8a664160e2056906b24bba44e80729b52a/pyhiveapi/apyhiveapi/session.py#L328) but otherwise leaves the `asyncio.Lock` in place. As a result, calling `updateData` generates the following warning:
```
/path/to/session.py:328: RuntimeWarning: coroutine 'Lock.acquire' was never awaited
  self.updateLock.acquire()
```
... and can throw the following exception if it attempts to [release the lock](https://github.com/Pyhass/Pyhiveapi/blob/05d5ae8a664160e2056906b24bba44e80729b52a/pyhiveapi/apyhiveapi/session.py#L335) without having acquired it:
```
[1/13/2024, 2:20:09 PM] Error: Python exception: Lock is not acquired.
```
This patch adds an `unasync` rule to convert the `asyncio.Lock` in `session.py` to `threading.Lock` instead. No other code is affected by this change.