### PR TITLE
Add a new exception for 'refresh token expired' to improve HA reauth flow

### DIFF
--- a/pyhiveapi/apyhiveapi/api/hive_auth_async.py
+++ b/pyhiveapi/apyhiveapi/api/hive_auth_async.py
@@ -21,6 +21,7 @@ from ..helper.hive_exceptions import (
     HiveInvalidDeviceAuthentication,
     HiveInvalidPassword,
     HiveInvalidUsername,
+    HiveRefreshTokenExpired,
 )
 from .hive_api import HiveApi
 
@@ -559,6 +560,9 @@ class HiveAuthAsync:
                 "NotAuthorizedException",
                 "CodeMismatchException",
             ):
+                if "Refresh Token has expired" in err.response.get(
+                    "Error", {}).get("Message", ""):
+                    raise HiveRefreshTokenExpired from err
                 raise HiveInvalid2FACode from err
         except botocore.exceptions.EndpointConnectionError as err:
             if err.__class__.__name__ == "EndpointConnectionError":

--- a/pyhiveapi/apyhiveapi/helper/hive_exceptions.py
+++ b/pyhiveapi/apyhiveapi/helper/hive_exceptions.py
@@ -25,6 +25,12 @@ class HiveApiError(Exception):
         Exception (object): Exception object to invoke
     """
 
+class HiveRefreshTokenExpired(Exception):
+    """Refresh token expired.
+
+    Args:
+        Exception (object): Exception object to invoke
+    """
 
 class HiveReauthRequired(Exception):
     """Re-Authentication is required.


### PR DESCRIPTION
While working on https://github.com/home-assistant/core/issues/147560

I found that apyhiveapi raised `apyhiveapi.helper.hive_exceptions.HiveInvalid2FACode` when trying to authenticate if the refresh token is invalid. This was not caught by HA (exception trace below), resulting in a non-specific error message on the UI and an error in the logs.

I think we can improve this. I see that the message in the authentication response includes the string "Refresh Token has expired".

I propose adding a new exception to specifically identify that the Refresh Token has expired. That can then be handled in the HA UI to trigger appropriate messages/reauth flows (in a separate HA core PR).

_I also considered raising 'HiveReauthRequired' at this point, which does work, and triggers a reauth flow on the HA UI straight away. It looks good and works, but there might be situations where the user doesn't want that. The main one being that this is triggered on HA startup, and results in the 2FA SMS message being sent, whether the user asked for it or not. So for example if you had a problem with hive, you would get a new SMS per reboot. Presumably this costs hive/BritishGas money, and would eventually trigger a block/cooldown period._

_Therefore I think the proposal is better because it allows the option of the user triggering a repair action to start the 2FA, and also allows a more meaningful error message to be displayed in the HA UI._


```
Traceback (most recent call last):
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/apyhiveapi/api/hive_auth_async.py", line 548, in refresh_token
    result = await self.loop.run_in_executor(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<7 lines>...
    )
    ^
  File "/usr/local/lib/python3.13/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/botocore/client.py", line 595, in _api_call
    return self._make_api_call(operation_name, kwargs)
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/botocore/context.py", line 123, in wrapper
    return func(*args, **kwargs)
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/botocore/client.py", line 1058, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.NotAuthorizedException: An error occurred (NotAuthorizedException) when calling the InitiateAuth operation: Refresh Token has expired

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/workspaces/core/homeassistant/config_entries.py", line 749, in __async_setup_with_context
    result = await component.async_setup_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/components/hive/__init__.py", line 43, in async_setup_entry
    devices = await hive.session.startSession(hive_config)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/apyhiveapi/session.py", line 502, in startSession
    await self.getDevices("No_ID")
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/apyhiveapi/session.py", line 425, in getDevices
    await self.hiveRefreshTokens()
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/apyhiveapi/session.py", line 304, in hiveRefreshTokens
    result = await self.auth.refresh_token(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        self.tokens.tokenData["refreshToken"]
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/apyhiveapi/api/hive_auth_async.py", line 562, in refresh_token
    raise HiveInvalid2FACode from err
apyhiveapi.helper.hive_exceptions.HiveInvalid2FACode
```